### PR TITLE
force landscape and use viewport to scale the screen

### DIFF
--- a/engine.cfg
+++ b/engine.cfg
@@ -6,6 +6,9 @@ icon="res://icon.png"
 
 [display]
 
+orientation="portrait"
+stretch_mode="viewport"
+stretch_aspect="keep"
 width=920
 height=1080
 


### PR DESCRIPTION
Depending on the device's screen resolution Godot will resize the game
screen, if necessary will put black boxes in the sides to fit the
resolution.

Closes #20