### PR TITLE
Add a series of tweaks to powerups

### DIFF
--- a/scenes/ball.xml
+++ b/scenes/ball.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<resource_file type="PackedScene" subresource_count="4" version="2.1" version_name="Godot Engine v2.1.3.stable.official">
+<resource_file type="PackedScene" subresource_count="4" version="2.1" version_name="Godot Engine v2.1.3.stable.custom_build">
 	<ext_resource path="res://scripts/ball.gd" type="Script" index="0"></ext_resource>
 	<ext_resource path="res://textures/ball.png" type="Texture" index="1"></ext_resource>
 	<resource type="RectangleShape2D" path="local://2">
@@ -17,7 +17,7 @@
 			<array  len="0" shared="false">
 			</array>
 			<string> "names" </string>
-			<string_array  len="35">
+			<string_array  len="36">
 				<string> "Ball" </string>
 				<string> "transform/scale" </string>
 				<string> "input/pickable" </string>
@@ -43,6 +43,7 @@
 				<string> "damp_override/angular" </string>
 				<string> "script/script" </string>
 				<string> "points_on_hit" </string>
+				<string> "points_for_winner" </string>
 				<string> "speedup" </string>
 				<string> "max_speed" </string>
 				<string> "RigidBody2D" </string>
@@ -60,9 +61,9 @@
 			<array  len="0" shared="false">
 			</array>
 			<string> "nodes" </string>
-			<int_array  len="85"> 				-1, -1, 27, 0, -1, 26, 1, 0, 2, 1, 3, 2, 4, 3, 5, 1, 6, 4, 7, 4, 8, 5, 9, 6, 10, 7, 11, 6, 12, 7, 13, 1, 14, 8, 15, 9, 16, 10, 17, 1, 18, 10, 19, 11, 20, 7, 21, 7, 22, 7, 23, 12, 24, 13, 25, 14, 26, 15, 0, 0, 0, 28, 28, -1, 2, 1, 0, 29, 16, 0, 0, 0, 34, 30, -1, 4, 1, 0, 31, 2, 32, 1, 33, 8, 0 </int_array>
+			<int_array  len="87"> 				-1, -1, 28, 0, -1, 27, 1, 0, 2, 1, 3, 2, 4, 3, 5, 1, 6, 4, 7, 4, 8, 5, 9, 6, 10, 7, 11, 6, 12, 7, 13, 1, 14, 8, 15, 9, 16, 10, 17, 1, 18, 10, 19, 11, 20, 7, 21, 7, 22, 7, 23, 12, 24, 13, 25, 14, 26, 15, 27, 16, 0, 0, 0, 29, 29, -1, 2, 1, 0, 30, 17, 0, 0, 0, 35, 31, -1, 4, 1, 0, 32, 2, 33, 1, 34, 8, 0 </int_array>
 			<string> "variants" </string>
-			<array  len="17" shared="false">
+			<array  len="18" shared="false">
 				<vector2> 0.5, 0.5 </vector2>
 				<bool> False </bool>
 				<resource  resource_type="Shape2D" path="local://2">  </resource>
@@ -77,6 +78,7 @@
 				<vector2> 0, -400 </vector2>
 				<resource  external="0">  </resource>
 				<int> 250 </int>
+				<int> 500 </int>
 				<int> 5 </int>
 				<int> 1500 </int>
 				<resource  external="1">  </resource>

--- a/scenes/expand_pad_powerup.xml
+++ b/scenes/expand_pad_powerup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<resource_file type="PackedScene" subresource_count="4" version="2.1" version_name="Godot Engine v2.1.3.stable.official">
+<resource_file type="PackedScene" subresource_count="4" version="2.1" version_name="Godot Engine v2.1.3.stable.custom_build">
 	<ext_resource path="res://textures/mario_mushroom_green.png" type="Texture" index="1"></ext_resource>
-	<ext_resource path="res://scripts/expand_tab_power_up.gd" type="Script" index="0"></ext_resource>
+	<ext_resource path="res://scripts/expand_pad_power_up.gd" type="Script" index="0"></ext_resource>
 	<resource type="CircleShape2D" path="local://1">
 		<real name="custom_solver_bias"> 0 </real>
 		<real name="radius"> 10 </real>
@@ -18,7 +18,7 @@
 			</array>
 			<string> "names" </string>
 			<string_array  len="33">
-				<string> "ExpandTabPowerUp" </string>
+				<string> "ExpandPadPowerUp" </string>
 				<string> "transform/scale" </string>
 				<string> "input/pickable" </string>
 				<string> "shapes/0/shape" </string>
@@ -58,25 +58,25 @@
 			<array  len="0" shared="false">
 			</array>
 			<string> "nodes" </string>
-			<int_array  len="81"> 				-1, -1, 24, 0, -1, 23, 1, 0, 2, 1, 3, 2, 4, 3, 5, 1, 6, 4, 7, 4, 8, 5, 9, 6, 10, 6, 11, 7, 12, 6, 13, 1, 14, 5, 15, 8, 16, 9, 17, 1, 18, 9, 19, 10, 20, 7, 21, 7, 22, 7, 23, 11, 0, 0, 0, 25, 25, -1, 2, 1, 12, 26, 13, 0, 0, 0, 32, 27, -1, 5, 28, 14, 1, 15, 29, 2, 30, 1, 31, 5, 0 </int_array>
+			<int_array  len="81"> 				-1, -1, 24, 0, -1, 23, 1, 0, 2, 1, 3, 2, 4, 3, 5, 1, 6, 4, 7, 4, 8, 4, 9, 5, 10, 5, 11, 6, 12, 5, 13, 1, 14, 7, 15, 8, 16, 9, 17, 1, 18, 9, 19, 10, 20, 6, 21, 6, 22, 6, 23, 11, 0, 0, 0, 25, 25, -1, 2, 1, 12, 26, 13, 0, 0, 0, 32, 27, -1, 5, 28, 14, 1, 15, 29, 2, 30, 1, 31, 7, 0 </int_array>
 			<string> "variants" </string>
 			<array  len="16" shared="false">
-				<vector2> 0.5, 0.5 </vector2>
+				<vector2> 0.3, 0.3 </vector2>
 				<bool> False </bool>
 				<resource  resource_type="Shape2D" path="local://1">  </resource>
-				<matrix32> 2.14062, -0, 0, 2.14062, -0.237431, 1.44317 </matrix32>
+				<matrix32> 1.25, -0, 0, 1.25, -0.237431, 1.44317 </matrix32>
 				<int> 2 </int>
-				<int> 0 </int>
 				<real> 1 </real>
 				<real> 0 </real>
+				<int> 0 </int>
 				<int> 3 </int>
 				<bool> True </bool>
-				<vector2> 0, 200 </vector2>
+				<vector2> 0, 300 </vector2>
 				<resource  external="0">  </resource>
 				<vector2> 0.2, 0.2 </vector2>
 				<resource  external="1">  </resource>
 				<vector2> -0.237431, 1.44317 </vector2>
-				<vector2> 2.14062, 2.14062 </vector2>
+				<vector2> 1.25, 1.25 </vector2>
 			</array>
 			<string> "version" </string>
 			<int> 2 </int>

--- a/scenes/level1.xml
+++ b/scenes/level1.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-
-<resource_file type="PackedScene" subresource_count="9" version="2.1" version_name="Godot Engine v2.1.3.stable.official">
-	<ext_resource path="res://scripts/world.gd" type="Script" index="0"></ext_resource>
+<resource_file type="PackedScene" subresource_count="9" version="2.1" version_name="Godot Engine v2.1.3.stable.custom_build">
 	<ext_resource path="res://scripts/paddle.gd" type="Script" index="1"></ext_resource>
 	<ext_resource path="res://scripts/bricks.gd" type="Script" index="3"></ext_resource>
+	<ext_resource path="res://scripts/world.gd" type="Script" index="0"></ext_resource>
 	<ext_resource path="res://textures/blue.png" type="Texture" index="2"></ext_resource>
 	<resource type="CapsuleShape2D" path="local://1">
 		<real name="custom_solver_bias"> 0 </real>
@@ -119,7 +118,7 @@
 				<real> 32 </real>
 				<real> 128 </real>
 				<string> "Score: 0" </string>
-				<vector2> 480.435, 1030.62 </vector2>
+				<vector2> 480.435, 1060 </vector2>
 				<vector2> 0.3, 0.3 </vector2>
 				<bool> False </bool>
 				<resource  resource_type="Shape2D" path="local://1">  </resource>

--- a/scenes/tele_control_powerup.xml
+++ b/scenes/tele_control_powerup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<resource_file type="PackedScene" subresource_count="4" version="2.1" version_name="Godot Engine v2.1.3.stable.official">
-	<ext_resource path="res://textures/mario_mushroom.png" type="Texture" index="1"></ext_resource>
+<resource_file type="PackedScene" subresource_count="4" version="2.1" version_name="Godot Engine v2.1.3.stable.custom_build">
 	<ext_resource path="res://scripts/tele_control_power_up.gd" type="Script" index="0"></ext_resource>
+	<ext_resource path="res://textures/mario_mushroom.png" type="Texture" index="1"></ext_resource>
 	<resource type="CircleShape2D" path="local://1">
 		<real name="custom_solver_bias"> 0 </real>
 		<real name="radius"> 10 </real>
@@ -61,10 +61,10 @@
 			<int_array  len="81"> 				-1, -1, 24, 0, -1, 23, 1, 0, 2, 1, 3, 2, 4, 3, 5, 1, 6, 4, 7, 4, 8, 5, 9, 6, 10, 6, 11, 7, 12, 6, 13, 1, 14, 5, 15, 8, 16, 9, 17, 1, 18, 9, 19, 10, 20, 7, 21, 7, 22, 7, 23, 11, 0, 0, 0, 25, 25, -1, 2, 1, 12, 26, 13, 0, 0, 0, 32, 27, -1, 5, 28, 14, 1, 15, 29, 2, 30, 1, 31, 5, 0 </int_array>
 			<string> "variants" </string>
 			<array  len="16" shared="false">
-				<vector2> 0.5, 0.5 </vector2>
+				<vector2> 0.3, 0.3 </vector2>
 				<bool> False </bool>
 				<resource  resource_type="Shape2D" path="local://1">  </resource>
-				<matrix32> 2.55093, 0, 0, 2.53849, 0.0502523, -0.0683169 </matrix32>
+				<matrix32> 2, -0, 0, 2, 0.0502523, -0.0683169 </matrix32>
 				<int> 2 </int>
 				<int> 0 </int>
 				<real> 1 </real>
@@ -73,10 +73,10 @@
 				<bool> True </bool>
 				<vector2> 0, 200 </vector2>
 				<resource  external="0">  </resource>
-				<vector2> 0.2, 0.2 </vector2>
+				<vector2> 0.15, 0.15 </vector2>
 				<resource  external="1">  </resource>
 				<vector2> 0.0502523, -0.0683169 </vector2>
-				<vector2> 2.55093, 2.53849 </vector2>
+				<vector2> 2, 2 </vector2>
 			</array>
 			<string> "version" </string>
 			<int> 2 </int>

--- a/scripts/ball.gd
+++ b/scripts/ball.gd
@@ -1,11 +1,14 @@
 extends RigidBody2D
 
-export var points_on_hit   = 250
+export var points_on_hit     = 250
 export var points_for_winner = 500
-export var speedup   = 5
-export var max_speed = 2000
+export var speedup           = 5
+export var max_speed         = 2000
 
-const powerup_telecontrol_acceleration = 2000
+var telecontrol_speedup_x          = 25
+var telecontrol_acceleration_x     = 40 setget increase_telecontrol_acceleration
+var min_telecontrol_acceleration_x = 40
+var max_telecontrol_acceleration_x = 120
 
 const game_over_scene = preload("res://scenes/game_over.xml")
 const winner_scene = preload("res://scenes/winner.xml")
@@ -13,17 +16,29 @@ const winner_scene = preload("res://scenes/winner.xml")
 func _ready():
 	set_fixed_process(true)
 
+func increase_telecontrol_acceleration():
+	telecontrol_acceleration_x = min(telecontrol_acceleration_x + telecontrol_speedup_x, max_telecontrol_acceleration_x)
+
 func _fixed_process(delta):
+	if get_pos().y > get_viewport_rect().end.y:
+		get_node("/root/World").update_high_score()
+		queue_free()
+		
+		var game_over_node = game_over_scene.instance()
+		get_node("..").add_child(game_over_node)
+	
 	var colliding_bodies = get_colliding_bodies()
 	
 	for body in colliding_bodies:
 		if body.is_in_group("Bricks"):
 			get_node("/root/World").score += points_on_hit
 			body.hit_brick()
+			
 			if get_tree().get_nodes_in_group("Bricks").size() == 1:
 				get_node("/root/World").score += points_for_winner
 				get_node("/root/World").update_high_score()
 				queue_free()
+				
 				var winner_node = winner_scene.instance()
 				get_node("..").add_child(winner_node)
 
@@ -33,24 +48,19 @@ func _fixed_process(delta):
 			var velocity  = direction.normalized() * min(speed + speedup, max_speed)
 			set_linear_velocity(velocity)
 
-	if get_node("/root/World").power_up_time_left_dict.has("TeleControl"):
-		var velocity_vec = get_linear_velocity()
-		var velocity_x = velocity_vec.x
-		var velocity_y = velocity_vec.y
+	if get_node("/root/World").get_active_powerups().has("TeleControl"):
+		var old_velocity = get_linear_velocity()
+		var velocity_x = old_velocity.x
+		var velocity_y = old_velocity.y
 		
-		# Calculating the acceleration multiplier
 		var ball_pos_x = get_pos().x
 		var paddle_pos_x = get_node("/root/World/Paddle").get_pos().x
+		
 		var screen_size_x = get_viewport().get_rect().size.x
 		var acceleration_multiplier = (paddle_pos_x - ball_pos_x) / screen_size_x
 		
-		# Calculating the acceleration
-		var acceleration = powerup_telecontrol_acceleration * acceleration_multiplier
-		var velocity = Vector2(velocity_x + acceleration * delta, velocity_y)
+		var acceleration = telecontrol_acceleration_x * acceleration_multiplier
+		var velocity = Vector2(velocity_x + acceleration, velocity_y)
 		set_linear_velocity(velocity)
-		
-	if get_pos().y > get_viewport_rect().end.y:
-		get_node("/root/World").update_high_score()
-		queue_free()
-		var game_over_node = game_over_scene.instance()
-		get_node("..").add_child(game_over_node)
+	else:
+		telecontrol_acceleration_x = min_telecontrol_acceleration_x

--- a/scripts/brick.gd
+++ b/scripts/brick.gd
@@ -2,12 +2,12 @@ extends StaticBody2D
 
 const powerup_scenes = {
 	"TeleControl": preload("res://scenes/tele_control_powerup.xml"),
-	"ExpandTab": preload("res://scenes/expand_tab_powerup.xml")
+	"ExpandTab": preload("res://scenes/expand_pad_powerup.xml")
 }
-var powerup_spawning_probability = 0.10
+var powerup_spawning_probability = 0.20
 
 var probabilities = [0.10, 0.20] setget set_prob
-var colors = [Color(30, 120, 20), Color(30, 60, 20), Color(60, 30, 20)]
+var colors = [Color(30, 90, 20), Color(90, 30, 20), Color(30, 20, 90)]
 var life_values = [0, 1, 2]
 var life
 
@@ -44,11 +44,10 @@ func spawn_powerup():
 	var random_powerup_index = powerup_scenes.size() * randf();
 	var random_powerup_key = powerup_scenes.keys()[random_powerup_index]
 	
-	if (not get_node("/root//World").power_up_time_left_dict.has(random_powerup_key)):
-		var power_up = powerup_scenes[random_powerup_key].instance()
-		power_up.set_pos(get_pos())
-		power_up.add_to_group("PowerUps")
-		get_node("/root/World").add_child(power_up)
+	var power_up = powerup_scenes[random_powerup_key].instance()
+	power_up.set_pos(get_pos())
+	power_up.add_to_group("PowerUps")
+	get_node("/root/World").add_child(power_up)
 
 func set_prob(probs):
 	probabilities = probs

--- a/scripts/expand_pad_power_up.gd
+++ b/scripts/expand_pad_power_up.gd
@@ -1,6 +1,7 @@
 extends RigidBody2D
 
-var kind = "ExpandTab"
+var name     = "ExpandPad"
+var duration = 6
 
 func _ready():
 	set_fixed_process(true)
@@ -10,6 +11,6 @@ func _fixed_process(delta):
 	
 	for body in colliding_bodies:
 		if body.get_name() == "Paddle":
-			var world_node = get_node("/root/World")
-			world_node.power_up_time_left_dict[kind] = 10
+			get_node("/root/World").update_active_powerups(name, duration)
+			body.expand_pad()
 			queue_free()

--- a/scripts/paddle.gd
+++ b/scripts/paddle.gd
@@ -1,7 +1,10 @@
 extends KinematicBody2D
 
 const ball_scene = preload("res://scenes/ball.xml")
-const default_scale = Vector2(0.3, 0.3)
+
+var default_scale = Vector2(0.3, 0.3)
+var max_scale     = Vector2(1.8, 0.3)
+
 var ball_presence = false
 var game_over = false
 
@@ -12,20 +15,25 @@ func _ready():
 func reset_scale():
 	set_scale(default_scale)
 	
-func double_horizontal_scale():
-	var new_scale = Vector2(default_scale.x * 2, default_scale.y)
-	set_scale(new_scale)
-	
+func scale_x_by(factor):
+	if (get_scale().x + (factor * default_scale.x) <= max_scale.x):
+		var new_scale = Vector2(get_scale().x + (default_scale.x * factor), default_scale.y)
+		set_scale(new_scale)
+
 func _fixed_process(delta):
 	if game_over: return
 	var y = get_pos().y
 	var mouse_x = get_viewport().get_mouse_pos().x
-	set_pos(Vector2(mouse_x, y))
-	if (get_parent().power_up_time_left_dict.has("ExpandTab")):
-		double_horizontal_scale()
-	else:
-		reset_scale()
 	
+	set_pos(Vector2(mouse_x, y))
+	
+	if (!get_parent().get_active_powerups().has("ExpandPad")):
+		reset_scale()
+
+func expand_pad():
+	if (get_parent().get_active_powerups().has("ExpandPad")):
+		scale_x_by(1)
+
 func _input(event):
 	if !ball_presence and (event.type == InputEvent.MOUSE_BUTTON and event.is_pressed()):
 		var ball = ball_scene.instance()

--- a/scripts/tele_control_power_up.gd
+++ b/scripts/tele_control_power_up.gd
@@ -1,6 +1,7 @@
 extends RigidBody2D
 
-var kind = "TeleControl"
+var name     = "TeleControl"
+var duration = 10
 
 func _ready():
 	set_fixed_process(true)
@@ -10,6 +11,6 @@ func _fixed_process(delta):
 	
 	for body in colliding_bodies:
 		if body.get_name() == "Paddle":
-			var world_node = get_node("/root/World")
-			world_node.power_up_time_left_dict[kind] = 10
+			get_node("/root/World").update_active_powerups(name, duration)
+			get_node("/root/Ball").increase_telecontrol_acceleration()
 			queue_free()

--- a/scripts/world.gd
+++ b/scripts/world.gd
@@ -6,7 +6,16 @@ var high_score_path = "user://high_score.save"
 var data = {"high_score": 0}
 var save_game = File.new()
 
-var power_up_time_left_dict = {}
+var active_powerups = {} setget update_active_powerups, get_active_powerups
+
+func update_active_powerups(powerup, time):
+	if (active_powerups.has(powerup)):
+		active_powerups[powerup] += time / 2
+	else:
+		active_powerups[powerup] = time
+
+func get_active_powerups():
+	return active_powerups
 
 func _ready():
 	load_high_score()
@@ -14,13 +23,12 @@ func _ready():
 	set_process(true)
 	
 func _process(delta):
-	for power_up in power_up_time_left_dict.keys():
-		var time_left = power_up_time_left_dict[power_up] - delta
+	for power_up in active_powerups.keys():
+		var time_left = active_powerups[power_up] - delta
 		if (time_left < 0):
-			power_up_time_left_dict.erase(power_up)
-			print("Power-up: %s was deactivated." % power_up)
+			active_powerups.erase(power_up)
 		else:
-			power_up_time_left_dict[power_up] = time_left
+			active_powerups[power_up] = time_left
 
 func update_high_score_label():
 	get_node("HighScore").set_text("High Score: " + str(high_score))

--- a/textures/powerup_icon.png.flags
+++ b/textures/powerup_icon.png.flags
@@ -1,2 +1,0 @@
-filter=true
-gen_mipmaps=true


### PR DESCRIPTION
- Rename 'tab' ~> 'pad'
- Rescale power up sprites
- Power ups now fall with different speeds
- Power ups have different durations
- Power up duration and intensity scales with more collections